### PR TITLE
Update git_repo pytest fixture to work with new API

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,23 +5,31 @@ from dulwich import porcelain
 
 
 @pytest.fixture(scope='session')
-def git_repo(path=None):
-    """Fixture creating git repo.
-    Can be used as a pytest fixture, in such case path where repo is created
-    is random, created using tempfile module.
-    If used as a function can be provided with path where the repo will be
-    created
-
-    :param path: path where repo will be created
-    :type path: string
-    :returns: porcelain object
+def git_repo():
+    """Fixture factory for returning a function which creates a git repo
+    
+    :returns: function
 
     """
-    if not path:
-        path = mkdtemp()
-    repo = porcelain.init(path)
-    config = repo.get_config()
-    config.set(b'user', b'name', b'Mr. Git')
-    config.set(b'user', b'email', b'mr.git@dulwich.co.uk')
-    config.write_to_path()
-    return repo
+    def _git_repo(path=None):
+        """Fixture creating git repo.
+        Can be used as a pytest fixture, in such case path where repo is created
+        is random, created using tempfile module.
+        If used as a function can be provided with path where the repo will be
+        created
+
+        :param path: path where repo will be created
+        :type path: string
+        :returns: porcelain object
+
+        """
+        if not path:
+            path = mkdtemp()
+        repo = porcelain.init(path)
+        config = repo.get_config()
+        config.set(b'user', b'name', b'Mr. Git')
+        config.set(b'user', b'email', b'mr.git@dulwich.co.uk')
+        config.write_to_path()
+        return repo
+
+    return _git_repo

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,7 +1,6 @@
 from click.testing import CliRunner
 
 from bamp.main import bamp
-from .conftest import git_repo
 
 
 def test_arg_part_missing():
@@ -72,7 +71,7 @@ def test_with_default_commit_no_vcs():
         assert result.exit_code == 1
 
 
-def test_default_tag_default_commit_with_vcs():
+def test_default_tag_default_commit_with_vcs(git_repo):
     """bamp patch -v 0.0.1 -f version.ini -ct"""
     runner = CliRunner()
     with runner.isolated_filesystem():
@@ -84,7 +83,7 @@ def test_default_tag_default_commit_with_vcs():
         assert result.exit_code == 0
 
 
-def test_custom_tag_default_commit_with_vcs():
+def test_custom_tag_default_commit_with_vcs(git_repo):
     """bamp patch -v 0.0.1 -f version.ini -c -t -T tag-{new_version}"""
     runner = CliRunner()
     with runner.isolated_filesystem():

--- a/tests/test_vcs_git.py
+++ b/tests/test_vcs_git.py
@@ -52,16 +52,16 @@ def test_get_repo_raise_exception():
 
 
 def test_create_commit_with_unicode_message(git_repo):
-    commit_sha1 = create_commit(git_repo, '', u'bździągwą')
+    commit_sha1 = create_commit(git_repo(), '', u'bździągwą')
     assert commit_sha1
 
 
 def test_create_commit_with_message(git_repo):
-    commit_sha1 = create_commit(git_repo, '', 'a')
+    commit_sha1 = create_commit(git_repo(), '', 'a')
     assert commit_sha1
 
 
 def test_create_tag_with_custom_name(git_repo):
-    commit_sha1 = create_commit(git_repo, '', 'Tag this commit')
-    tag = create_tag(git_repo, commit_sha1, 'tag-commit')
+    commit_sha1 = create_commit(git_repo(), '', 'Tag this commit')
+    tag = create_tag(git_repo(), commit_sha1, 'tag-commit')
     assert tag

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35
+envlist = py27,py34,py35,py36,py37
 
 [testenv]
 deps =


### PR DESCRIPTION
You're no longer able to call fixtures directly in pytest, so this changes the `git_repo` fixture into a factory to inject a function into tests which require it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inirudebwoy/bamp/18)
<!-- Reviewable:end -->
