### PR TITLE
Limit how many instances of the version number is changed. Fixes #27

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,14 @@ This allows to set the version number. This number will be seeked in files and
 bamped accordingly. Bamp fails if the version can not be located.
 
     version=0.1.0
+
+limit | -l/--limit
+------------------
+Limit how many occurrences of the version number will be updated in each file.
+For example, if you `version=1.2.3` string is near the top of your file, but it
+also contains version specifiers for other requirements, such as `django>=1.2.3`,
+then the default limit of 1 will ensure that only the first occurrence is updated.
+If you'd prefer to update all occurrences, then set `limit=0`. `limit` may be set
+to any positive integer to update that many occurrences.
+
+    limit=1

--- a/bamp/helpers/docs.py
+++ b/bamp/helpers/docs.py
@@ -20,3 +20,4 @@ COMMIT_FLAG_OPTION_HELP = (
 )
 CONFIG_OPTION_HELP = "Path to a config file."
 DEBUG_OPTION_HELP = "Enable debug flag."
+LIMIT_OPTION_HELP = "Limit the number of instances of version to be bamped in each file."

--- a/bamp/main.py
+++ b/bamp/main.py
@@ -72,6 +72,7 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
     help=docs.TAG_NAME_OPTION_HELP,
     metavar=docs.TAG_NAME_OPTION_METAVAR,
 )
+@click.option("limit", "-l", "--limit", help=docs.LIMIT_OPTION_HELP, type=int, default=1)
 @click.argument(
     "part", nargs=1, type=click.Choice(["patch", "minor", "major", "current"])
 )
@@ -89,6 +90,7 @@ def bamp(
     config,
     tag,
     tag_name,
+    limit,
 ):
     root_path = get_root_path()
     sanity_checks(root_path)
@@ -100,7 +102,7 @@ def bamp(
     if dry_run:
         return machine_out(new_version)
 
-    bamp_files(version, new_version, files)
+    bamp_files(version, new_version, files, limit)
 
     if commit:
         commit_message = make_message(message, version, new_version)

--- a/bamp/persistence.py
+++ b/bamp/persistence.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 @verify_response
-def bamp_files(cur_version, new_version, files):
+def bamp_files(cur_version, new_version, files, limit=1):
     """Replace current version with new version in every file from list
     of files.
     If there is a problem with accessing any one of the files, operation is
@@ -27,31 +27,34 @@ def bamp_files(cur_version, new_version, files):
     :type new_version: str
     :param files: list of paths which to bamp
     :type files: list
+    :param limit: how many times to replace version in file (default 1)
+    :type limit: int
     :returns: True, [] if env is sane, False and list of error message
               otherwise
     :rtype: tuple(bool, list(str))
 
-
     """
     bamped_files = []
     errors = []
-    for f in files:
-        try:
-            bamped_files.append(_file_bamper(cur_version, new_version, f))
-        except IOError:
-            errors.append("Error accessing file: {0}".format(f))
-        except VersionNotFound:
-            errors.append("Version {0} not found in {1}".format(cur_version, f))
+    try:
+        for f in files:
+            try:
+                bamped_files.append(_file_bamper(cur_version, new_version, f, limit))
+            except IOError:
+                errors.append("Error accessing file: {0}".format(f))
+            except VersionNotFound:
+                errors.append("Version {0} not found in {1}".format(cur_version, f))
 
-    if errors:
-        return False, errors
+        if errors:
+            return False, errors
 
-    for orig, bamped in bamped_files:
-        copy(bamped, orig)
+        for orig, bamped in bamped_files:
+            copy(bamped, orig)
 
-    # clear temps
-    _rm_files([p.copy for p in bamped_files])
-    return True, []
+        return True, []
+    finally:
+        # clear temps
+        _rm_files([p.copy for p in bamped_files])
 
 
 def _rm_files(file_list):

--- a/bamp/persistence.py
+++ b/bamp/persistence.py
@@ -74,7 +74,7 @@ def _ver_is_found(version, line):
     return bool(re.search(ver_re, line))
 
 
-def _file_bamper(cur_version, new_version, file_path):
+def _file_bamper(cur_version, new_version, file_path, limit=1):
     """Replace version in file
 
     Function works on a copy of a original file and returns
@@ -88,6 +88,8 @@ def _file_bamper(cur_version, new_version, file_path):
     :type new_version: str
     :param file_path: path to file with current version
     :type file_path: str
+    :param limit: how many times to replace version in file (default 1)
+    :type limit: int
     :returns: tuple with original file and bamped copy
     :rtype: PathPair namedtuple
 
@@ -95,11 +97,13 @@ def _file_bamper(cur_version, new_version, file_path):
     _, copy_path = mkstemp()
     with open(copy_path, mode="w", encoding="utf-8") as cf:
         with open(file_path, encoding="utf-8") as of:
-            found = False
+            found = 0
             for line in of.readlines():
                 if _ver_is_found(cur_version, line):
-                    found = True
+                    found += 1
                     line = line.replace(cur_version, new_version)
+                    if found >= limit:
+                        break
                 cf.write(line)
             if not found:
                 raise VersionNotFound()

--- a/bamp/persistence.py
+++ b/bamp/persistence.py
@@ -100,10 +100,9 @@ def _file_bamper(cur_version, new_version, file_path, limit=1):
             found = 0
             for line in of.readlines():
                 if _ver_is_found(cur_version, line):
+                    if found < limit or limit == 0:
+                        line = line.replace(cur_version, new_version)
                     found += 1
-                    line = line.replace(cur_version, new_version)
-                    if found >= limit:
-                        break
                 cf.write(line)
             if not found:
                 raise VersionNotFound()

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -106,3 +106,57 @@ def test_custom_tag_default_commit_with_vcs():
             ],
         )
         assert result.exit_code == 0
+
+def test_limit_default():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("version.ini", "w", encoding="utf-8") as v:
+            v.write("""\
+first_version=1.33.7
+second_version=1.33.7
+third_version=1.33.7
+""")
+        result = runner.invoke(bamp, ["patch", "-v", "1.33.7", "-f", "version.ini"])
+        assert result.exit_code == 0
+        with open("version.ini", "r", encoding="utf-8") as v:
+            assert v.read() == """\
+first_version=1.33.8
+second_version=1.33.7
+third_version=1.33.7
+"""
+
+def test_limit_2():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("version.ini", "w", encoding="utf-8") as v:
+            v.write("""\
+first_version=1.33.7
+second_version=1.33.7
+third_version=1.33.7
+""")
+        result = runner.invoke(bamp, ["patch", "-v", "1.33.7", "-f", "version.ini", "-l", "2"])
+        assert result.exit_code == 0
+        with open("version.ini", "r", encoding="utf-8") as v:
+            assert v.read() == """\
+first_version=1.33.8
+second_version=1.33.8
+third_version=1.33.7
+"""
+
+def test_limit_0():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("version.ini", "w", encoding="utf-8") as v:
+            v.write("""\
+first_version=1.33.7
+second_version=1.33.7
+third_version=1.33.7
+""")
+        result = runner.invoke(bamp, ["patch", "-v", "1.33.7", "-f", "version.ini", "-l", "0"])
+        assert result.exit_code == 0
+        with open("version.ini", "r", encoding="utf-8") as v:
+            assert v.read() == """\
+first_version=1.33.8
+second_version=1.33.8
+third_version=1.33.8
+"""

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,5 +1,7 @@
-from bamp.persistence import _ver_is_found
+import os
+from tempfile import NamedTemporaryFile
 
+from bamp.persistence import _ver_is_found, _file_bamper
 
 def test_issue_15():
     assert not _ver_is_found("1.0.22", 'INTERNAL_IPS = ["127.1.0.22"]')
@@ -20,3 +22,61 @@ def test_version_in_configuration():
     assert _ver_is_found("1.1.1", "version = 'v1.1.1'")
     assert _ver_is_found("1.1.1", "'v1.1.1'\n")
     assert _ver_is_found("1.1.1", " v1.1.1\n")
+
+def test_limit_default():
+    with NamedTemporaryFile("w", encoding="utf-8") as f:
+        f.write("""\
+first_version=1.33.7
+second_version=1.33.7
+third_version=1.33.7
+""")
+        f.flush()
+        _, new_file = _file_bamper("1.33.7", "1.33.8", f.name)
+        try:
+            with open(new_file, "r", encoding="utf-8") as nf:
+                assert nf.read() == """\
+first_version=1.33.8
+second_version=1.33.7
+third_version=1.33.7
+"""
+        finally:
+            os.remove(new_file)
+
+
+def test_limit_2():
+    with NamedTemporaryFile("w", encoding="utf-8") as f:
+        f.write("""\
+first_version=1.33.7
+second_version=1.33.7
+third_version=1.33.7
+""")
+        f.flush()
+        _, new_file = _file_bamper("1.33.7", "1.33.8", f.name, limit=2)
+        try:
+            with open(new_file, "r", encoding="utf-8") as nf:
+                assert nf.read() == """\
+first_version=1.33.8
+second_version=1.33.8
+third_version=1.33.7
+"""
+        finally:
+            os.remove(new_file)
+
+def test_limit_0():
+    with NamedTemporaryFile("w", encoding="utf-8") as f:
+        f.write("""\
+first_version=1.33.7
+second_version=1.33.7
+third_version=1.33.7
+""")
+        f.flush()
+        _, new_file = _file_bamper("1.33.7", "1.33.8", f.name, limit=0)
+        try:
+            with open(new_file, "r", encoding="utf-8") as nf:
+                assert nf.read() == """\
+first_version=1.33.8
+second_version=1.33.8
+third_version=1.33.8
+"""
+        finally:
+            os.remove(new_file)


### PR DESCRIPTION
Changes the default behaviour (!) to only bamp a single occurrence of the version number. Can perhaps be extended in the future if the previous behaviour is desired (`--no-limit`) or a different limit is desired (`--limit 4`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inirudebwoy/bamp/28)
<!-- Reviewable:end -->
